### PR TITLE
Add a UAST modal to SqlLab tab

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@ flake8==3.6.0
 flask-cors==3.0.6
 ipdb==0.11
 mysqlclient==1.3.13
-pip-tools==3.1.0
+pip-tools==3.6.1
 psycopg2-binary==2.7.5
 pycodestyle==2.4.0
 pyhive==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ decorator==4.3.0          # via retry
 defusedxml==0.5.0         # via python3-openid
 docker-pycreds==0.4.0     # via docker
 docker==3.7.2             # via bblfsh
-flask-appbuilder==1.12.5
+flask-appbuilder==1.12.1
 flask-babel==0.11.1       # via flask-appbuilder
 flask-caching==1.4.0
 flask-compress==1.4.0
@@ -56,7 +56,6 @@ protobuf==3.7.1           # via bblfsh, grpcio-tools
 py==1.7.0                 # via retry
 pycparser==2.19           # via cffi
 pydruid==0.5.0
-pyjwt==1.7.1              # via flask-appbuilder
 python-dateutil==2.6.1
 python-editor==1.0.3      # via alembic
 python-geohash==0.8.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ alembic==1.0.0            # via flask-migrate
 amqp==2.3.2               # via kombu
 asn1crypto==0.24.0        # via cryptography
 babel==2.6.0              # via flask-babel
+bblfsh==3.0.3
 billiard==3.5.0.4         # via celery
 bleach==3.0.2
 celery==4.2.0
@@ -21,7 +22,9 @@ croniter==0.3.29
 cryptography==2.4.2
 decorator==4.3.0          # via retry
 defusedxml==0.5.0         # via python3-openid
-flask-appbuilder==1.12.1
+docker-pycreds==0.4.0     # via docker
+docker==3.7.2             # via bblfsh
+flask-appbuilder==1.12.5
 flask-babel==0.11.1       # via flask-appbuilder
 flask-caching==1.4.0
 flask-compress==1.4.0
@@ -32,6 +35,8 @@ flask-sqlalchemy==2.3.2   # via flask-appbuilder, flask-migrate
 flask-wtf==0.14.2
 flask==1.0.2
 geopy==1.11.0
+grpcio-tools==1.20.1      # via bblfsh
+grpcio==1.20.1            # via bblfsh, grpcio-tools
 gunicorn==19.8.0
 humanize==0.5.1
 idna==2.6
@@ -47,9 +52,11 @@ pandas==0.23.4
 parsedatetime==2.0.0
 pathlib2==2.3.0
 polyline==1.3.2
+protobuf==3.7.1           # via bblfsh, grpcio-tools
 py==1.7.0                 # via retry
 pycparser==2.19           # via cffi
 pydruid==0.5.0
+pyjwt==1.7.1              # via flask-appbuilder
 python-dateutil==2.6.1
 python-editor==1.0.3      # via alembic
 python-geohash==0.8.5
@@ -60,7 +67,7 @@ requests==2.20.0
 retry==0.9.2
 selenium==3.141.0
 simplejson==3.15.0
-six==1.11.0               # via bleach, cryptography, isodate, pathlib2, polyline, pydruid, python-dateutil, sqlalchemy-utils, wtforms-json
+six==1.11.0               # via bleach, cryptography, docker, docker-pycreds, grpcio, isodate, pathlib2, polyline, protobuf, pydruid, python-dateutil, sqlalchemy-utils, websocket-client, wtforms-json
 sqlalchemy-utils==0.32.21
 sqlalchemy==1.2.2
 sqlparse==0.2.4
@@ -68,6 +75,7 @@ unicodecsv==0.14.1
 urllib3==1.22             # via requests, selenium
 vine==1.1.4               # via amqp
 webencodings==0.5.1       # via bleach
+websocket-client==0.56.0  # via docker
 werkzeug==0.14.1          # via flask
 wtforms-json==0.3.3
 wtforms==2.2.1            # via flask-wtf, wtforms-json

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
     zip_safe=False,
     scripts=['superset/bin/superset'],
     install_requires=[
+        'bblfsh>=3.0.3',
         'bleach>=3.0.2, <4.0.0',
         'celery>=4.2.0, <5.0.0',
         'click>=6.0, <7.0.0',  # click >=7 forces "-" instead of "_"

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         'croniter>=0.3.28',
         'cryptography>=2.4.2',
         'flask>=1.0.0, <2.0.0',
-        'flask-appbuilder>=1.12.1, <2.0.0',
+        'flask-appbuilder==1.12.1',
         'flask-caching',
         'flask-compress',
         'flask-migrate',

--- a/superset/assets/package-lock.json
+++ b/superset/assets/package-lock.json
@@ -4746,6 +4746,11 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
+    "codemirror": {
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.46.0.tgz",
+      "integrity": "sha512-3QpMge0vg4QEhHW3hBAtCipJEWjTJrqLLXdIaWptJOblf1vHFeXLNtFhPai/uX2lnFCehWNk4yOdaMR853Z02w=="
+    },
     "collapse-white-space": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz",
@@ -15614,6 +15619,11 @@
         }
       }
     },
+    "react-codemirror2": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-5.1.0.tgz",
+      "integrity": "sha512-Cksbgbviuf2mJfMyrKmcu7ycK6zX/ukuQO8dvRZdFWqATf5joalhjFc6etnBdGCcPA2LbhIwz+OPnQxLN/j1Fw=="
+    },
     "react-color": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.14.1.tgz",
@@ -19501,6 +19511,11 @@
       "version": "0.7.19",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
       "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
+    },
+    "uast-viewer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/uast-viewer/-/uast-viewer-0.4.0.tgz",
+      "integrity": "sha512-1Q2b6bJr4JLeANADFaN2/LgOUvFo+1lWtweVkbYXr0MFpioVhlpaw+Z+1ygGcnGwoJ0MR96jBg4Eqb8PtA6RJQ=="
     },
     "uglify-js": {
       "version": "3.4.9",

--- a/superset/assets/package.json
+++ b/superset/assets/package.json
@@ -69,6 +69,7 @@
     "brace": "^0.11.1",
     "classnames": "^2.2.5",
     "d3": "^3.5.17",
+    "codemirror": "^5.46.0",
     "d3-array": "^1.2.4",
     "d3-cloud": "^1.2.1",
     "d3-color": "^1.2.0",
@@ -102,6 +103,7 @@
     "react-bootstrap": "^0.31.5",
     "react-bootstrap-dialog": "^0.10.0",
     "react-bootstrap-slider": "2.1.5",
+    "react-codemirror2": "^5.1.0",
     "react-color": "^2.13.8",
     "react-datetime": "^2.14.0",
     "react-dnd": "^2.5.4",
@@ -132,6 +134,7 @@
     "shortid": "^2.2.6",
     "srcdoc-polyfill": "^1.0.0",
     "supercluster": "^4.1.1",
+    "uast-viewer": "^0.4.0",
     "underscore": "^1.8.3",
     "urijs": "^1.18.10",
     "viewport-mercator-project": "^5.0.0"

--- a/superset/assets/src/components/FilterableTable/CellRenderer.jsx
+++ b/superset/assets/src/components/FilterableTable/CellRenderer.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import React from 'react';
 import UASTButton from './UASTButton';
 

--- a/superset/assets/src/components/FilterableTable/CellRenderer.jsx
+++ b/superset/assets/src/components/FilterableTable/CellRenderer.jsx
@@ -2,7 +2,16 @@
 import React from 'react';
 import UASTButton from './UASTButton';
 
-export default function cellRenderer({
+function isUAST(st) {
+  try {
+    JSON.parse(st);
+    return st.includes('"@pos"');
+  } catch (error) {
+    return false;
+  }
+}
+
+function cellRenderer({
   cellData,
   columnData,
   columnIndex,
@@ -12,10 +21,11 @@ export default function cellRenderer({
   rowIndex,
 }) {
   const st = String(cellData);
-  if (st.includes('"@pos"')) {
+  if (isUAST(st)) {
     return (<UASTButton uast={st} />);
   }
 
   return st;
 }
 
+export { cellRenderer, isUAST };

--- a/superset/assets/src/components/FilterableTable/CellRenderer.jsx
+++ b/superset/assets/src/components/FilterableTable/CellRenderer.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import UASTButton from './UASTButton';
+
+export default function cellRenderer({
+  cellData,
+  columnData,
+  columnIndex,
+  dataKey,
+  isScrolling,
+  rowData,
+  rowIndex,
+}) {
+  const st = String(cellData);
+  if (st.includes('"@pos"')) {
+    return (<UASTButton uast={st} />);
+  }
+
+  return st;
+}
+

--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -28,7 +28,7 @@ import {
 } from 'react-virtualized';
 import { getTextWidth } from '../../modules/visUtils';
 
-import cellRenderer from './CellRenderer';
+import { cellRenderer, isUAST } from './CellRenderer';
 
 const propTypes = {
   orderedColumnKeys: PropTypes.array.isRequired,
@@ -84,7 +84,7 @@ export default class FilterableTable extends PureComponent {
       const colWidths = this.list
         .map((d) => {
           // TODO hardcoded, implement a better way
-          if (d[key].includes('"@pos"')) {
+          if (isUAST(d[key])) {
             return 150;
           }
 

--- a/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -28,6 +28,8 @@ import {
 } from 'react-virtualized';
 import { getTextWidth } from '../../modules/visUtils';
 
+import cellRenderer from './CellRenderer';
+
 const propTypes = {
   orderedColumnKeys: PropTypes.array.isRequired,
   data: PropTypes.array.isRequired,
@@ -80,7 +82,14 @@ export default class FilterableTable extends PureComponent {
     const widthsByColumnKey = {};
     this.props.orderedColumnKeys.forEach((key) => {
       const colWidths = this.list
-        .map(d => getTextWidth(d[key]) + PADDING) // get width for each value for a key
+        .map((d) => {
+          // TODO hardcoded, implement a better way
+          if (d[key].includes('"@pos"')) {
+            return 150;
+          }
+
+          return getTextWidth(d[key]) + PADDING;
+        }) // get width for each value for a key
         .push(getTextWidth(key) + PADDING); // add width of column key to end of list
       // set max width as value for key
       widthsByColumnKey[key] = Math.max(...colWidths);
@@ -201,6 +210,7 @@ export default class FilterableTable extends PureComponent {
                 dataKey={columnKey}
                 disableSort={false}
                 headerRenderer={this.headerRenderer}
+                cellRenderer={cellRenderer}
                 width={this.widthsForColumnsByKey[columnKey]}
                 label={columnKey}
                 key={columnKey}

--- a/superset/assets/src/components/FilterableTable/UASTButton.jsx
+++ b/superset/assets/src/components/FilterableTable/UASTButton.jsx
@@ -1,0 +1,54 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Button } from 'react-bootstrap';
+
+import UASTModal from '../../uast/components/UASTModal';
+
+class UastButton extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showModal: false,
+    };
+  }
+
+  render() {
+    // Ideally there would be a UASTModal in a higher html element, and this
+    // button onClick would send a redux action to show the modal. To make
+    // the code as independent as possible from the rest of Superset the
+    // UASTModal is contained in this row cell.
+    // To avoid actually having one hidden modal per row cell, it is defined
+    // as null unless we are really going to open the modal.
+
+    let modal = null;
+
+    if (this.state.showModal) {
+      const uast = JSON.parse(this.props.uast);
+
+      modal = (<UASTModal
+        show={this.state.showModal}
+        uast={uast}
+        onHide={() => this.setState({ showModal: false })}
+      />);
+    }
+
+    return (
+      <div>
+        <Button
+          bsSize="small"
+          onClick={() => this.setState({ showModal: true })}
+        >
+          <i className="fa fa-align-left text-muted" /> UAST
+        </Button>
+        {modal}
+      </div>);
+  }
+}
+
+UastButton.propTypes = {
+  actions: PropTypes.object,
+  uast: PropTypes.string,
+};
+
+export default  UastButton;

--- a/superset/assets/src/uast/components/UASTModal.jsx
+++ b/superset/assets/src/uast/components/UASTModal.jsx
@@ -1,0 +1,38 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Modal } from 'react-bootstrap';
+
+import UASTViewer from './UASTViewer';
+import '../stylesheets/UASTModal.less';
+
+class UastModal extends React.PureComponent {
+  render() {
+    let modalContent = <div />;
+    let showModal = false;
+
+    if (this.props.uast) {
+      showModal = true;
+      modalContent = <UASTViewer uast={this.props.uast} />;
+    }
+
+    return (
+      <Modal
+        show={showModal}
+        onHide={this.props.onHide}
+        bsSize="large"
+      >
+        <Modal.Header closeButton>
+          <Modal.Title>UAST</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>{modalContent}</Modal.Body>
+      </Modal>);
+  }
+}
+
+UastModal.propTypes = {
+  show: PropTypes.bool.isRequired,
+  uast: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onHide: PropTypes.func.isRequired,
+};
+
+export default UastModal;

--- a/superset/assets/src/uast/components/UASTViewer.jsx
+++ b/superset/assets/src/uast/components/UASTViewer.jsx
@@ -1,12 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { expandRootIds, uastV2 } from 'uast-viewer';
 import UASTViewerPane from './UASTViewerPane';
-
-// Same values as the ones applied by withUASTEditor in CodeViewer.js
-// https://github.com/bblfsh/uast-viewer/blob/v0.2.0/src/withUASTEditor.js#L208
-const ROOT_IDS = [1];
-const LEVELS_EXPAND = 2;
 
 class UASTViewer extends Component {
   constructor(props) {
@@ -14,7 +8,6 @@ class UASTViewer extends Component {
 
     this.state = {
       loading: false,
-      initialFlatUast: this.transform(props.uast),
       showLocations: false,
     };
 
@@ -25,22 +18,9 @@ class UASTViewer extends Component {
     this.setState({ showLocations: !this.state.showLocations });
   }
 
-  // Applies the uast-viewer object shape transformer, and expands the first
-  // 2 levels
-  transform(uast) {
-    const flatUAST = uastV2.transformer(uast);
-    return expandRootIds(
-      flatUAST,
-      ROOT_IDS,
-      LEVELS_EXPAND,
-      uastV2.getChildrenIds,
-    );
-  }
-
   render() {
-    const { initialFlatUast, loading } = this.state;
-    const { showLocations } = this.state;
-    const uastViewerProps = { initialFlatUast };
+    const { showLocations, loading } = this.state;
+    const uastViewerProps = { initialUast: this.props.uast };
 
     return (
       <div className="pg-uast-viewer">

--- a/superset/assets/src/uast/components/UASTViewer.jsx
+++ b/superset/assets/src/uast/components/UASTViewer.jsx
@@ -1,0 +1,63 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { expandRootIds, uastV2 } from 'uast-viewer';
+import UASTViewerPane from './UASTViewerPane';
+
+// Same values as the ones applied by withUASTEditor in CodeViewer.js
+// https://github.com/bblfsh/uast-viewer/blob/v0.2.0/src/withUASTEditor.js#L208
+const ROOT_IDS = [1];
+const LEVELS_EXPAND = 2;
+
+class UASTViewer extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      loading: false,
+      initialFlatUast: this.transform(props.uast),
+      showLocations: false,
+    };
+
+    this.handleShowLocationsChange = this.handleShowLocationsChange.bind(this);
+  }
+
+  handleShowLocationsChange() {
+    this.setState({ showLocations: !this.state.showLocations });
+  }
+
+  // Applies the uast-viewer object shape transformer, and expands the first
+  // 2 levels
+  transform(uast) {
+    const flatUAST = uastV2.transformer(uast);
+    return expandRootIds(
+      flatUAST,
+      ROOT_IDS,
+      LEVELS_EXPAND,
+      uastV2.getChildrenIds,
+    );
+  }
+
+  render() {
+    const { initialFlatUast, loading } = this.state;
+    const { showLocations } = this.state;
+    const uastViewerProps = { initialFlatUast };
+
+    return (
+      <div className="pg-uast-viewer">
+        <UASTViewerPane
+          loading={loading}
+          uastViewerProps={uastViewerProps}
+          showLocations={showLocations}
+          handleShowLocationsChange={this.handleShowLocationsChange}
+        />
+      </div>
+    );
+  }
+}
+
+UASTViewer.propTypes = {
+  uast: PropTypes.array,
+  protobufs: PropTypes.string,
+};
+
+export default UASTViewer;

--- a/superset/assets/src/uast/components/UASTViewerPane.jsx
+++ b/superset/assets/src/uast/components/UASTViewerPane.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import FlatUASTViewer from 'uast-viewer';
+import UASTViewer from 'uast-viewer';
 import 'uast-viewer/dist/default-theme.css';
 import '../stylesheets/UASTViewerPane.less';
 
@@ -35,7 +35,7 @@ function UASTViewerPane({
 }) {
   let content = null;
 
-  const uast = uastViewerProps.flatUast || uastViewerProps.initialFlatUast;
+  const uast = uastViewerProps.uast || uastViewerProps.initialUast;
   if (loading) {
     content = <div>loading...</div>;
   } else if (uast) {
@@ -46,7 +46,7 @@ function UASTViewerPane({
       content = <NotFound />;
     } else {
       content = (
-        <FlatUASTViewer
+        <UASTViewer
           {...uastViewerProps}
           rootIds={rootIds}
           showLocations={showLocations}

--- a/superset/assets/src/uast/components/UASTViewerPane.jsx
+++ b/superset/assets/src/uast/components/UASTViewerPane.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FlatUASTViewer from 'uast-viewer';
+import 'uast-viewer/dist/default-theme.css';
+import '../stylesheets/UASTViewerPane.less';
+
+const ROOT_ID = 1;
+
+function getSearchResults(flatUast) {
+  if (!flatUast) {
+    return null;
+  }
+
+  const rootNode = flatUast[ROOT_ID];
+  if (!rootNode) {
+    return null;
+  }
+
+  if (Array.isArray(rootNode.n)) {
+    return rootNode.n.map(c => c.id);
+  }
+
+  return null;
+}
+
+function NotFound() {
+  return <div>Nothing found</div>;
+}
+
+function UASTViewerPane({
+  loading,
+  uastViewerProps,
+  showLocations,
+  handleShowLocationsChange,
+}) {
+  let content = null;
+
+  const uast = uastViewerProps.flatUast || uastViewerProps.initialFlatUast;
+  if (loading) {
+    content = <div>loading...</div>;
+  } else if (uast) {
+    const searchResults = getSearchResults(uast);
+    const rootIds = searchResults || [ROOT_ID];
+
+    if (searchResults && !searchResults.length) {
+      content = <NotFound />;
+    } else {
+      content = (
+        <FlatUASTViewer
+          {...uastViewerProps}
+          rootIds={rootIds}
+          showLocations={showLocations}
+        />
+      );
+    }
+  }
+
+  return (
+    <div className="uast-viewer-pane">
+      <div className="show-locations-wrapper">
+        <label htmlFor="showLocations">
+          <input
+            id="showLocations"
+            type="checkbox"
+            checked={showLocations}
+            onChange={handleShowLocationsChange}
+          />
+          <span>Show locations</span>
+        </label>
+      </div>
+      {content}
+    </div>
+  );
+}
+
+UASTViewerPane.propTypes = {
+  loading: PropTypes.bool,
+  uastViewerProps: PropTypes.object,
+  showLocations: PropTypes.bool,
+  handleShowLocationsChange: PropTypes.func.isRequired,
+};
+
+export default UASTViewerPane;

--- a/superset/assets/src/uast/components/UASTViewerPane.jsx
+++ b/superset/assets/src/uast/components/UASTViewerPane.jsx
@@ -4,29 +4,6 @@ import UASTViewer from 'uast-viewer';
 import 'uast-viewer/dist/default-theme.css';
 import '../stylesheets/UASTViewerPane.less';
 
-const ROOT_ID = 1;
-
-function getSearchResults(flatUast) {
-  if (!flatUast) {
-    return null;
-  }
-
-  const rootNode = flatUast[ROOT_ID];
-  if (!rootNode) {
-    return null;
-  }
-
-  if (Array.isArray(rootNode.n)) {
-    return rootNode.n.map(c => c.id);
-  }
-
-  return null;
-}
-
-function NotFound() {
-  return <div>Nothing found</div>;
-}
-
 function UASTViewerPane({
   loading,
   uastViewerProps,
@@ -39,20 +16,12 @@ function UASTViewerPane({
   if (loading) {
     content = <div>loading...</div>;
   } else if (uast) {
-    const searchResults = getSearchResults(uast);
-    const rootIds = searchResults || [ROOT_ID];
-
-    if (searchResults && !searchResults.length) {
-      content = <NotFound />;
-    } else {
-      content = (
-        <UASTViewer
-          {...uastViewerProps}
-          rootIds={rootIds}
-          showLocations={showLocations}
-        />
-      );
-    }
+    content = (
+      <UASTViewer
+        {...uastViewerProps}
+        showLocations={showLocations}
+      />
+    );
   }
 
   return (

--- a/superset/assets/src/uast/stylesheets/UASTModal.less
+++ b/superset/assets/src/uast/stylesheets/UASTModal.less
@@ -1,0 +1,9 @@
+// make modal window "fullscreen"
+.modal-lg .modal-body {
+    height: ~'calc(100vh - 150px)';
+
+    .uast-viewer {
+        height: 100%;
+        overflow-y: auto;
+    }
+}

--- a/superset/assets/src/uast/stylesheets/UASTViewerPane.less
+++ b/superset/assets/src/uast/stylesheets/UASTViewerPane.less
@@ -1,0 +1,31 @@
+.uast-viewer-pane {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+
+    .show-locations-wrapper {
+        flex: 0 0 auto;
+
+        min-height: 45px;
+        padding: 5px 0px 5px 20px;
+        background: white;
+        border-bottom: solid 1px fade(gray, 50%);
+
+        label {
+            font-weight: normal;
+            margin-right: 40px;
+
+            span {
+                margin-left: 10px;
+            }
+
+            &:last-of-type {
+                margin-right: 10px;
+            }
+        }
+    }
+
+    .uast-viewer {
+        flex: 1 1 auto;
+    }
+}

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -56,6 +56,7 @@ from sqlalchemy.types import TEXT, TypeDecorator
 from superset.exceptions import SupersetException, SupersetTimeoutException
 from superset.utils.dates import datetime_to_epoch, EPOCH
 
+from bblfsh.pyuast import decode
 
 logging.getLogger('MARKDOWN').setLevel(logging.INFO)
 
@@ -342,10 +343,13 @@ def base_json_conv(obj):
         return str(obj)
     elif isinstance(obj, bytes):
         try:
-            return '{}'.format(obj)
+            ctx = decode(obj, format=0)
+            return json.dumps(ctx.load())
         except Exception:
-            return '[bytes]'
-
+            try:
+                return '{}'.format(obj)
+            except Exception:
+                return '[bytes]'
 
 def json_iso_dttm_ser(obj, pessimistic=False):
     """

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -35,6 +35,7 @@ from typing import Optional
 import uuid
 import zlib
 
+from bblfsh.pyuast import decode
 import bleach
 import celery
 from dateutil.parser import parse
@@ -55,8 +56,6 @@ from sqlalchemy.types import TEXT, TypeDecorator
 
 from superset.exceptions import SupersetException, SupersetTimeoutException
 from superset.utils.dates import datetime_to_epoch, EPOCH
-
-from bblfsh.pyuast import decode
 
 logging.getLogger('MARKDOWN').setLevel(logging.INFO)
 
@@ -350,6 +349,7 @@ def base_json_conv(obj):
                 return '{}'.format(obj)
             except Exception:
                 return '[bytes]'
+
 
 def json_iso_dttm_ser(obj, pessimistic=False):
     """


### PR DESCRIPTION
Frontend code based on gitbase-web, removing things related to search.
The backend transforms the UAST blobs to JSON for every row.

I tried to keep the code changes as localized and minimal as possible. This is why `UASTModal` is placed inside each row cell with UAST contents. It would make more sense to have one Modal, for example as part of `FilterableTable`, and set the visibility and the contents via redux actions. But the way it's done in this PR the state can be controlled with local state and props easily, leading to uglier code, but more independent of the main codebase.

I didn't change the default UAST css because that will also involve the code from bblfsh-web tab.

To upgrade requirements.txt I had to upgrade `pip-tools` to 3.6.1. The version shipped in `requirements.txt` was not working for me, `pip-compile --output-file requirements.txt setup.py` failed.
I guess this is why some dependencies not related to `bblfsh` were also updated in `requirements.txt`, like `flask-appbuilder`. I don't feel comfortable with these updates, but `requirements.txt` is auto generated, and editing it manually doesn't sound good either.

![image](https://user-images.githubusercontent.com/1469173/57030817-e0b0d180-6c3d-11e9-8e52-ca95573c7478.png)

![image](https://user-images.githubusercontent.com/1469173/57030844-f45c3800-6c3d-11e9-84eb-1a301901869d.png)
